### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-dockerhub/main.go
+++ b/cmd/baton-dockerhub/main.go
@@ -46,7 +46,7 @@ func getConnector(ctx context.Context, cfg *config.Dockerhub) (types.ConnectorSe
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, cfg.Username, cfg.AccessToken, cfg.Password, cfg.Orgs)
+	cb, err := connector.New(ctx, cfg.Username, cfg.AccessToken, cfg.Password, cfg.Orgs, cfg.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Dockerhub struct {
 	AccessToken string `mapstructure:"access-token"`
 	Password string `mapstructure:"password"`
 	Orgs []string `mapstructure:"orgs"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Dockerhub) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the DockerHub API URL (for testing)"),
 		field.WithDisplayName("Base URL"),
+		field.WithHidden(true),
 	)
 
 	// FieldRelationships defines relationships between the fields.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,11 @@ var (
 		field.WithDescription("Limit syncing to specific organizations by providing organization slugs."),
 		field.WithDisplayName("Organizations"),
 	)
+	BaseURL = field.StringField(
+		"base-url",
+		field.WithDescription("Override the DockerHub API URL (for testing)"),
+		field.WithDisplayName("Base URL"),
+	)
 
 	// FieldRelationships defines relationships between the fields.
 	FieldRelationships = []field.SchemaFieldRelationship{
@@ -42,6 +47,7 @@ var Configuration = field.NewConfiguration([]field.SchemaField{
 	AccessToken,
 	Password,
 	Orgs,
+	BaseURL,
 }, field.WithConstraints(FieldRelationships...))
 
 // ValidateConfig is run after the configuration is loaded, and should return an

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ var (
 		field.WithDescription("Override the DockerHub API URL (for testing)"),
 		field.WithDisplayName("Base URL"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// FieldRelationships defines relationships between the fields.

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -55,10 +55,10 @@ func (dh *DockerHub) Validate(ctx context.Context) (annotations.Annotations, err
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, username, accessToken, password string, orgs []string) (*DockerHub, error) {
+func New(ctx context.Context, username, accessToken, password string, orgs []string, baseURL string) (*DockerHub, error) {
 	l := ctxzap.Extract(ctx)
 	l.Debug("creating client")
-	hubClient, err := dockerhub.NewClient(ctx, username, password, accessToken)
+	hubClient, err := dockerhub.NewClient(ctx, username, password, accessToken, baseURL)
 	if err != nil {
 		l.Error("error creating client", zap.Error(err))
 		return nil, err

--- a/pkg/dockerhub/client.go
+++ b/pkg/dockerhub/client.go
@@ -54,10 +54,17 @@ type TokenResp struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-func NewClient(ctx context.Context, username, password, accessToken string) (*Client, error) {
+func NewClient(ctx context.Context, username, password, accessToken, baseURL string) (*Client, error) {
 	base := &url.URL{
 		Scheme: "https",
 		Host:   BaseDomain,
+	}
+	if baseURL != "" {
+		var err error
+		base, err = url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base URL: %w", err)
+		}
 	}
 
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-dockerhub/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/dockerhub/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-dockerhub --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DockerHub configuration now supports a customizable base URL parameter, enabling connections to alternative registry endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->