### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a Docker Hub connector"
 og:title: "Set up a Docker Hub connector"
-description: "C1 provides identity governance and just-in-time provisioning for Docker Hub. Integrate your Docker Hub instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "C1 provides identity governance and just-in-time provisioning for Docker Hub. Integrate your Docker Hub instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for Docker Hub. Integrate your Docker Hub instance with C1 for unified visibility and governance over user access."
+og:description: "C1 provides identity governance for Docker Hub. Integrate your Docker Hub instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Docker Hub"
 ---
 
@@ -23,7 +23,7 @@ Here's the set of credentials you'll need when setting up the connector:
 
 - The username and password of a Docker Hub account
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Docker Hub connector
 
@@ -74,7 +74,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your Docker Hub connector is now pulling access data into C1.
+**Done.** Your Docker Hub connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -189,7 +189,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Docker Hub connector is now pulling access data into C1.
+**Done.** Your Docker Hub connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines