### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -33,15 +33,14 @@ func teamResource(ctx context.Context, team *dockerhub.Team, parentId *v2.Resour
 		"team_name": team.Name,
 	}
 
-	teamTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	teamTraitOptions := []rs.GroupTraitOption{}
 
 	resource, err := rs.NewGroupResource(
 		team.Name,
 		resourceTypeTeam,
 		team.Id,
 		teamTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentId),
 		rs.WithDescription(team.Description),
 	)
@@ -117,12 +116,7 @@ func (t *teamResourceType) Entitlements(_ context.Context, resource *v2.Resource
 
 // Grants returns a slice of grants for each member that team contain.
 func (t *teamResourceType) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	teamGroupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	teamSlug, ok := rs.GetProfileStringValue(teamGroupTrait.Profile, "team_name")
+	teamSlug, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "team_name")
 	if !ok {
 		return nil, "", nil, fmt.Errorf("dockerhub-connector: failed to get team name from profile")
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -31,8 +31,6 @@ func userResource(ctx context.Context, user *dockerhub.User, parentId *v2.Resour
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 		rs.WithEmail(user.Email, true),
 	}
 
@@ -41,6 +39,8 @@ func userResource(ctx context.Context, user *dockerhub.User, parentId *v2.Resour
 		resourceTypeUser,
 		user.Id,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
 		rs.WithParentResourceID(parentId),
 	)
 


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
